### PR TITLE
fix: board styling params were not being used

### DIFF
--- a/example/lib/kanban/board_builder.dart
+++ b/example/lib/kanban/board_builder.dart
@@ -45,6 +45,12 @@ class _KanbanCanvasState extends State<KanbanCanvas> {
                 ),
                 groupConstraints: groupConstraints,
                 itemGhost: ghost,
+                groupGhost: Container(
+                  color: Colors.red,
+                  height: 100,
+                  width: 100,
+                ),
+                
                 groupItemBuilder: groupItemBuilder,
               ),
             )

--- a/lib/src/board.dart
+++ b/lib/src/board.dart
@@ -211,7 +211,7 @@ class _BoardState extends ConsumerState<Board> {
   }
 
   /// [_activateBoardScrollListeners] activates the board scroll listeners.
-  /// only when drgaggable offset is updated, it notifies the newly group-items, groups came into view.
+  /// only when draggable offset is updated, it notifies the newly group-items, groups came into view.
   void _activateBoardScrollListeners() {
     final boardState = ref.read(_boardStateController);
     // Group Scroll Listener

--- a/lib/src/widgets/board-group/board_groups_root.dart
+++ b/lib/src/widgets/board-group/board_groups_root.dart
@@ -41,12 +41,6 @@ class BoardGroupsRoot extends ConsumerStatefulWidget {
 }
 
 class _BoardGroupsRootState extends ConsumerState<BoardGroupsRoot> {
-  bool _showNewGroup = false;
-  void createNewGroup() {
-    setState(() {
-      _showNewGroup = true;
-    });
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -79,13 +73,7 @@ class _BoardGroupsRootState extends ConsumerState<BoardGroupsRoot> {
                   groupConstraints: widget.groupConstraints,
                 ),
             ],
-            _showNewGroup
-                ? Container(
-                    height: 300,
-                    width: 300,
-                    color: Colors.purple,
-                  )
-                : widget.trailing ?? Container(),
+            widget.trailing ?? Container(),
           ],
         ),
       ),

--- a/lib/src/widgets/board-group/group_placeholder_wrapper.dart
+++ b/lib/src/widgets/board-group/group_placeholder_wrapper.dart
@@ -69,13 +69,18 @@ class _GroupPlaceholderWrapperState
                     child: child,
                   );
                 },
-                child: Opacity(
-                  opacity: 0.6,
-                  child: Container(
-                    margin: const EdgeInsets.only(right: LIST_GAP),
-                    child: draggingState.draggingWidget,
-                  ),
-                ))
+                child: Container(
+                  width: draggingState.feedbackSize.width,
+                  margin: const EdgeInsets.only(right: LIST_GAP),
+                  child: boardState.groupGhost ??
+                      Opacity(
+                        opacity: 0.6,
+                        child: Container(
+                          child: draggingState.draggingWidget,
+                        ),
+                      ),
+                ),
+              )
             : Container(),
         SlideTransition(
           position: Tween<Offset>(
@@ -102,12 +107,16 @@ class _GroupPlaceholderWrapperState
                     child: child,
                   );
                 },
-                child: Opacity(
-                  opacity: 0.6,
-                  child: Container(
-                    margin: const EdgeInsets.only(right: LIST_GAP),
-                    child: draggingState.draggingWidget,
-                  ),
+                child: Container(
+                  margin: const EdgeInsets.only(right: LIST_GAP),
+                  width: draggingState.feedbackSize.width,
+                  child: boardState.groupGhost ??
+                      Opacity(
+                        opacity: 0.6,
+                        child: Container(
+                          child: draggingState.draggingWidget,
+                        ),
+                      ),
                 ),
               )
             : Container(),


### PR DESCRIPTION
**_Problem:_**
`groupGhost`, `trailing` Widget was not being rendered when passed to the package.

**_Solution:_**
Displayed them, if provided.